### PR TITLE
Fix: Wrong interface conversion (ITfcompositionSink)

### DIFF
--- a/src/IME/SampleIME.cpp
+++ b/src/IME/SampleIME.cpp
@@ -156,7 +156,7 @@ STDAPI CSampleIME::QueryInterface(REFIID riid, _Outptr_ void **ppvObj)
     }
     else if (IsEqualIID(riid, IID_ITfCompositionSink))
     {
-        *ppvObj = (ITfKeyEventSink *)this;
+        *ppvObj = (ITfCompositionSink *)this;
     }
     else if (IsEqualIID(riid, IID_ITfDisplayAttributeProvider))
     {


### PR DESCRIPTION
Issue Description:
In the `CSampleIME::QueryInterface` method, when a client requests the `IID_ITfCompositionSink` interface, the code incorrectly casts the object to `ITfKeyEventSink*` instead of the correct `ITfCompositionSink*`.

Fix Details:
- File: `FanImeTsf/src/IME/SampleIME.cpp`
- Line: Line 159
- Change: Corrected the erroneous interface cast from `(ITfKeyEventSink *)this` to the proper `(ITfCompositionSink *)this`